### PR TITLE
Setting the `light` parameter in the `VoxelManip:write_to_map()` to optional

### DIFF
--- a/classes/VoxelManip.lua
+++ b/classes/VoxelManip.lua
@@ -22,7 +22,7 @@ function VoxelManip:read_from_map(position1, position2) end
 ---       all modified blocks with `minetest.fix_light()` as soon as possible.
 ---       Keep in mind that modifying the map where light is incorrect can cause
 ---       more lighting bugs.
---- @param light boolean Default: true
+--- @param light boolean? Default: true
 function VoxelManip:write_to_map(light) end
 --- Returns a `MapNode` table of the node currently loaded in
 ---   the `VoxelManip` at that position


### PR DESCRIPTION
Этот параметр в методе может быть не указан

<img width="926" height="220" alt="изображение" src="https://github.com/user-attachments/assets/905ee65b-0324-42bf-b3be-4c6c642ba83e" />

